### PR TITLE
Update benchmarks

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -33,7 +33,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.f4b6a3</groupId>
+    <groupId>io.hypersistence</groupId>
     <artifactId>benchmark</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -47,8 +47,8 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
     <properties>
     
-	    <dependency.groupid>com.github.f4b6a3</dependency.groupid>
-	    <dependency.artifactid>tsid-creator</dependency.artifactid>
+	    <dependency.groupid>io.hypersistence</dependency.groupid>
+	    <dependency.artifactid>hypersistence-tsid</dependency.artifactid>
 	    <dependency.version>0.0.1-BENCHMARK</dependency.version>
 		<dependency.path>${project.basedir}/../target/${dependency.artifactid}-${dependency.version}.jar</dependency.path>
 
@@ -99,6 +99,13 @@ THE POSSIBILITY OF SUCH DAMAGE.
                     <compilerVersion>${javac.target}</compilerVersion>
                     <source>${javac.target}</source>
                     <target>${javac.target}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 			<plugin>

--- a/benchmark/run.bat
+++ b/benchmark/run.bat
@@ -8,7 +8,7 @@ REM compile the parent project
 CALL mvn clean install -DskipTests
 
 REM create a copy with the expected name
-XCOPY /Y target\tsid-creator-*-SNAPSHOT.jar target\tsid-creator-0.0.1-BENCHMARK.jar*
+XCOPY /Y target\hypersistence-tsid-*-SNAPSHOT.jar target\hypersistence-tsid-0.0.1-BENCHMARK.jar*
 
 REM go to the benchmark folder
 CD benchmark

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ARTIFACT_ID=tsid-creator
+ARTIFACT_ID=hypersistence-tsid
 
 # find the script folder
 SCRIPT_DIR=$(dirname "$0")

--- a/benchmark/src/main/java/benchmark/Throughput.java
+++ b/benchmark/src/main/java/benchmark/Throughput.java
@@ -15,7 +15,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
-import io.hypersistence.tsid.Tsid;
+import io.hypersistence.tsid.TSID;
 
 @Fork(1)
 @Threads(4)
@@ -37,42 +37,42 @@ public class Throughput {
 	}
 
 	@Benchmark
-	public Tsid Tsid_fast() {
-		return Tsid.fast();
+	public TSID TSID_fast() {
+		return TSID.fast();
 	}
 
 	@Benchmark
-	public String Tsid_fast_toString() {
-		return Tsid.fast().toString();
+	public String TSID_fast_toString() {
+		return TSID.fast().toString();
 	}
 
 	@Benchmark
-	public Tsid TsidCreator_getTsid256() {
-		return TsidCreator.getTsid256();
+	public TSID TSID_Factory_getTsid256() {
+		return TSID.Factory.getTsid256();
 	}
 
 	@Benchmark
-	public String TsidCreator_getTsid256_toString() {
-		return TsidCreator.getTsid256().toString();
+	public String TSID_Factory_getTsid256_toString() {
+		return TSID.Factory.getTsid256().toString();
 	}
 
 	@Benchmark
-	public Tsid TsidCreator_getTsid1024() {
-		return TsidCreator.getTsid1024();
+	public TSID TSID_Factory_getTsid1024() {
+		return TSID.Factory.getTsid1024();
 	}
 
 	@Benchmark
-	public String TsidCreator_getTsid1024_toString() {
-		return TsidCreator.getTsid1024().toString();
+	public String TSID_Factory_getTsid1024_toString() {
+		return TSID.Factory.getTsid1024().toString();
 	}
 
 	@Benchmark
-	public Tsid TsidCreator_getTsid4096() {
-		return TsidCreator.getTsid4096();
+	public TSID TSID_Factory_getTsid4096() {
+		return TSID.Factory.getTsid4096();
 	}
 
 	@Benchmark
-	public String TsidCreator_getTsid4096_toString() {
-		return TsidCreator.getTsid4096().toString();
+	public String TSID_Factory_getTsid4096_toString() {
+		return TSID.Factory.getTsid4096().toString();
 	}
 }


### PR DESCRIPTION
Updates the benchmark files and applies a [small `pom.xml` fix](https://github.com/f4b6a3/ulid-creator/issues/34#issuecomment-2764692682) for development machines using JDK 22+ due to annotation processing being disabled by default.

To execute the benchmark, run the script `./benchmark/run.sh`.
